### PR TITLE
74 conversation list view maintains selection on refresh

### DIFF
--- a/reviver/controller.py
+++ b/reviver/controller.py
@@ -29,6 +29,8 @@ class Controller(QObject):
     message_updated = Signal(str, str, str)
     message_complete = Signal()
     refresh_active_conversation = Signal()
+    new_active_conversation = Signal()
+
 
     def __init__(self, data_directory: Path) -> None:
         super().__init__()
@@ -58,14 +60,16 @@ class Controller(QObject):
         self.message_added.connect(self.store_active_conversation)
 
     def set_active_bot(self, bot_name):
-        self.active_bot_name = bot_name
-        bot = self.bot_manager.get_bot(self.active_bot_name)
-        # if self.convo_manager.active_conversation is not None:
-        self.convo_manager.active_conversation.bot = bot
+        if bot_name:
+            log.info(f"Setting active bot to {bot_name}")
+            self.active_bot_name = bot_name
+            bot = self.bot_manager.get_bot(self.active_bot_name)
+            # if self.convo_manager.active_conversation is not None:
+            self.convo_manager.active_conversation.bot = bot
         
-        # pass in message added signal
-        self.convo_manager.active_conversation.update_system_prompt(self.refresh_active_conversation)
-        self.store_active_conversation()
+            # pass in message added signal
+            self.convo_manager.active_conversation.update_system_prompt() # self.refresh_active_conversation)
+            self.store_active_conversation()
 
     def add_bot(self, bot_name: str) -> bool:
         """
@@ -141,7 +145,7 @@ class Controller(QObject):
         self.active_bot_name = bot_name
         self.convo_manager.new_active_conversation(bot)
         self.archive.store_conversation(self.convo_manager.active_conversation)
-        self.refresh_active_conversation.emit()
+        self.new_active_conversation.emit()
 
     def store_active_conversation(self):
         self.archive.store_conversation(self.convo_manager.active_conversation)
@@ -160,9 +164,15 @@ class Controller(QObject):
 
     def set_active_conversation(self, conversation_title:str):
         self.convo_manager.set_active_conversation(conversation_title)
-        self.refresh_active_conversation.emit()
+        self.new_active_conversation.emit()
 
-        
+
+    def get_active_conversation_title(self):
+        title = None
+        if self.convo_manager.active_conversation is not None:
+            title = self.convo_manager.active_conversation.title
+        return title
+     
     def rename_conversation(self, old_title, new_title):
         pass
 

--- a/reviver/controller.py
+++ b/reviver/controller.py
@@ -68,7 +68,8 @@ class Controller(QObject):
             self.convo_manager.active_conversation.bot = bot
         
             # pass in message added signal
-            self.convo_manager.active_conversation.update_system_prompt() # self.refresh_active_conversation)
+            self.convo_manager.active_conversation.update_system_prompt() 
+            self.refresh_active_conversation.emit()
             self.store_active_conversation()
 
     def add_bot(self, bot_name: str) -> bool:

--- a/reviver/conversation.py
+++ b/reviver/conversation.py
@@ -25,7 +25,7 @@ class Conversation:
         # Note this will override a previous system prompt if the bot or bot prompt have changed
         self.update_system_prompt()
 
-    def update_system_prompt(self, refresh_conversation:Signal=None):       
+    def update_system_prompt(self): # , refresh_conversation:Signal=None):       
         if 0 in self.messages.keys():
             log.info(f"Updating system prompt for {self.title}")
             prompt_message_time = self.messages[0].time
@@ -34,9 +34,6 @@ class Conversation:
 
         prompt_message = Message(role = "system", content=self.bot.system_prompt, time=prompt_message_time)
         self.messages[0] = prompt_message
-        if refresh_conversation is not None:
-            refresh_conversation.emit()
-        
         
     def _add_message(self, msg:Message)->None:
         self.messages[self.message_count] = msg

--- a/reviver/conversation_manager.py
+++ b/reviver/conversation_manager.py
@@ -11,6 +11,8 @@ from os import getenv
 from datetime import datetime
 from reviver.message import Message
 from reviver.conversation import Conversation
+import reviver.log
+log = reviver.log.get(__name__)
 
 @dataclass(frozen=False, slots=True)
 class ConversationManager:
@@ -46,11 +48,12 @@ class ConversationManager:
 
         return conversation_titles
     
-    def new_active_conversation(self,bot:Bot)->None:
+    def new_active_conversation(self,bot:Bot):
         """
         When starting a conversation it will always become the 
         active conversation
         """
+
         convo_title = str(datetime.now())
         for char in [":", " ", ".", "-"]:
             convo_title = convo_title.replace(char, "")
@@ -58,7 +61,7 @@ class ConversationManager:
         convo = Conversation(bot=bot, title=convo_title)
         self.conversations[convo_title] = convo
         self.active_conversation = convo
-
+    
 
     def set_active_conversation(self, convo_title):
         self.active_conversation = self.conversations[convo_title]

--- a/reviver/gui/active_conversation_widget.py
+++ b/reviver/gui/active_conversation_widget.py
@@ -68,7 +68,7 @@ class ActiveConversationWidget(QWidget):
         self.controller.message_added.connect(self.add_message)
         self.controller.message_updated.connect(self.update_message)
         self.controller.refresh_active_conversation.connect(self.display_active_conversation)
-
+        self.controller.new_active_conversation.connect(self.display_active_conversation)
     
     def send_user_message(self):
         log.info(f"Sending: {self.text_entry.toPlainText()}")


### PR DESCRIPTION
Spontaneous updating of active conversation now occurring when either manually selecting text item or toggling via keyboard. 

Some changes made to minimize instances of passing Signal deeper into model than the controller level. Hopefully should now be primarily the weird instance of the conversation streaming updates...and honestly I could just manage that with a Queue if I wanted to...

Otherwise things are working a little bit more smoothly. Definitely minimize pushing signals all over the place as it quickly becomes difficult to keep track of what in the heck is going on...